### PR TITLE
Do not use namespace for package

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -19,7 +19,7 @@
     }
   ],
   "suffix": ".bs.js",
-  "namespace": true,
+  "namespace": false,
   "bs-dependencies": [],
   "bs-dev-dependencies": [
     "rescript-test"


### PR DESCRIPTION
`Jzon` name alone defines a clear boundary