### PR TITLE
Add data-first encode/decode function versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,26 @@ First, define their _codecs_:
 ```rescript
 module Codecs = {
   let style = Jzon.object2(
+    // Function to encode original object to linear tuple
     ({size, color}) => (size, color),
+
+    // Function to decode linear tuple back to object
     ((size, color)) => {size, color}->Ok,
+
+    // Field names and codecs for the tuple elements
     Jzon.field("size", Jzon.float),
     Jzon.field("color", Jzon.string),
   );
 
+  // Similar codec for another record type
   let point = Jzon.object4(
     ({x, y, z, style}) => (x, y, z, style),
     ((x, y, z, style)) => {x, y, z, style}->Ok,
     Jzon.field("x", Jzon.float),
     Jzon.field("y", Jzon.float),
+    // ... supports default values
     Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+    // ... may refer your other codecs
     Jzon.field("style", style)->Jzon.optional,
   )
 }
@@ -54,18 +62,18 @@ module Codecs = {
 Next, convert between the ReScript types and `Js.Json.t` with:
 
 ```rescript
-let myJsonData =
-  Codecs.point
-  ->Jzon.encode({
-    x: 1.0,
-    y: 2.0,
-    z: 3.0,
-    style: Some({size: 4.0, color: "#fd0"}),
-  })
+let myPoint = {
+  x: 1.0,
+  y: 2.0,
+  z: 3.0,
+  style: Some({size: 4.0, color: "#fd0"}),
+}
+
+let json = myPoint->Jzon.encodeWith(Codecs.point)
 ```
 
 and back with:
 
 ```rescript
-let myPoint = Codecs.point->Jzon.decode(myJsonData)
+let myPoint = json->Jzon.decodeWith(Codecs.point)
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,18 +20,27 @@ Defines a field descriptor used to encode and decode an object field of type `'v
 
 ```rescript
 let decode: (codec<'v>, Js.Json.t) => result<'v, DecodingError.t>
+let decodeWith: (Js.Json.t, codec<'v>) => result<'v, DecodingError.t>
 let decodeString: (codec<'v>, string) => result<'v, DecodingError.t>
+let decodeStringWith: (string, codec<'v>) => result<'v, DecodingError.t>
 ```
 
 Decode payload given a codec. The functions never throw as long as custom codecs and object constructors do not throw.
+
+If you are in doubt which argument order to prefer, use data-first (i.e. `decodeWith`) for the sake of consistency. Usage experience shows it fits long pipe `->` chains `->` nicely.
 
 ### Encoding
 
 ```rescript
 let encode: (codec<'v>, 'v) => Js.Json.t
+let encodeWith: ('v, codec<'v>) => Js.Json.t
+let encodeString: (codec<'v>, 'v) => string
+let encodeStringWith: ('v, codec<'v>) => string
 ```
 
-Encodes a value with the given codec. The function always succeeds as long as custom codecs and object destructors do not throw.
+Encodes a value with the given codec. The functions always succeed as long as custom codecs and object destructors do not throw.
+
+If you are in doubt which argument order to prefer, use data-first (i.e. `encodeWith`) for the sake of consistency. Usage experience shows it fits long pipe `->` chains `->` nicely.
 
 ### Simple codecs
 

--- a/src/Jzon.res
+++ b/src/Jzon.res
@@ -101,10 +101,14 @@ module Codec = {
 type codec<'v> = Codec.t<'v>
 
 let encode = Codec.encode
+let encodeWith = (data, codec) => codec->encode(data)
 let encodeString = Codec.encodeString
+let encodeStringWith = (data, codec) => codec->encodeString(data)
 
 let decode = Codec.decode
+let decodeWith = (json, codec) => codec->decode(json)
 let decodeString = Codec.decodeString
+let decodeStringWith = (string, codec) => codec->decodeString(string)
 
 let custom = Codec.make
 

--- a/src/Jzon.resi
+++ b/src/Jzon.resi
@@ -18,10 +18,14 @@ type codec<'v>
 type field<'v>
 
 let decode: (codec<'v>, Js.Json.t) => result<'v, DecodingError.t>
+let decodeWith: (Js.Json.t, codec<'v>) => result<'v, DecodingError.t>
 let decodeString: (codec<'v>, string) => result<'v, DecodingError.t>
+let decodeStringWith: (string, codec<'v>) => result<'v, DecodingError.t>
 
 let encode: (codec<'v>, 'v) => Js.Json.t
+let encodeWith: ('v, codec<'v>) => Js.Json.t
 let encodeString: (codec<'v>, 'v) => string
+let encodeStringWith: ('v, codec<'v>) => string
 
 let custom: ('v => Js.Json.t, Js.Json.t => result<'v, DecodingError.t>) => codec<'v>
 

--- a/tests/Basics_test.res
+++ b/tests/Basics_test.res
@@ -9,12 +9,12 @@ test("Scalar types", () => {
 })
 
 test("Int codec", () => {
-  Jzon.int
-  ->Jzon.decodeString("42.5")
+  "42.5"
+  ->Jzon.decodeStringWith(Jzon.int)
   ->Assert.errorString("Unexpected value 42.5 at .", ~message="Barks on fractional numbers")
 
-  Jzon.int
-  ->Jzon.decodeString("9111222333")
+  "9111222333"
+  ->Jzon.decodeStringWith(Jzon.int)
   ->Assert.errorString("Unexpected value 9111222333 at .", ~message="Barks on out-of-range numbers")
 })
 
@@ -26,15 +26,15 @@ test("Nullable", () => {
   )
 
   Assert.roundtrips(None, Jzon.nullable(Jzon.string), ~message="None does roundtrip")
-  Jzon.nullable(Jzon.string)
-  ->Jzon.encode(None)
+
+  None
+  ->Jzon.encodeWith(Jzon.nullable(Jzon.string))
   ->Assert.equals(Js.Json.null, ~message="Encodes as `null`")
 })
 
 test("Null as", () => {
-  Jzon.int
-  ->Jzon.nullAs(100)
-  ->Jzon.decodeString("null")
+  "null"
+  ->Jzon.decodeStringWith(Jzon.int->Jzon.nullAs(100))
   ->Assert.okOf(100, ~message="Decodes null as value provided")
 })
 
@@ -45,20 +45,20 @@ test("Array", () => {
     ~message="array<int> does roundtrip",
   )
 
-  Jzon.array(Jzon.int)
-  ->Jzon.decodeString(`[1, 2, "three", 4]`)
+  `[1, 2, "three", 4]`
+  ->Jzon.decodeStringWith(Jzon.array(Jzon.int))
   ->Assert.errorString(
     "Expected number, got string at .[2]",
     ~message="Barks on unexpected type with proper path",
   )
 
-  Jzon.array(Jzon.nullable(Jzon.int))
-  ->Jzon.decodeString(`[1, 2, null, 4]`)
+  `[1, 2, null, 4]`
+  ->Jzon.decodeStringWith(Jzon.array(Jzon.nullable(Jzon.int)))
   ->Assert.okOf([Some(1), Some(2), None, Some(4)], ~message="Handles nullables")
 })
 
 test("JSON with syntax error", () => {
-  Jzon.json
-  ->Jzon.decodeString(`{"color": "#09a", size: 5.0}`)
+  `{"color": "#09a", size: 5.0}`
+  ->Jzon.decodeStringWith(Jzon.json)
   ->Assert.errorString("Unexpected token s in JSON at position 18", ~message="Errors")
 })

--- a/tests/Dict_test.res
+++ b/tests/Dict_test.res
@@ -9,12 +9,12 @@ test("Roundtrip", () => {
 })
 
 test("Decoding", () => {
-  Jzon.dict(Jzon.int)
-  ->Jzon.decodeString(`{
-      "one": 1,
-      "two": 2,
-      "three": "борщ"
-    }`)
+  `{
+    "one": 1,
+    "two": 2,
+    "three": "борщ"
+  }`
+  ->Jzon.decodeStringWith(Jzon.dict(Jzon.int))
   ->Assert.errorString(
     `Expected number, got string at ."three"`,
     ~message="errors on wrong value type",

--- a/tests/Howtos_test.res
+++ b/tests/Howtos_test.res
@@ -276,12 +276,9 @@ module HowtoDependentSchemaNested = {
         // Depending on the "kind" field value take a proper payload codec
         // and build the value in the ReScript world
         switch kind {
-        | "circle" =>
-          json->Jzon.decodeWith(circle)->Result.map(geo => Circle(geo))
-        | "rectangle" =>
-          json->Jzon.decodeWith(rectangle)->Result.map(geo => Rectangle(geo))
-        | "ellipse" =>
-          json->Jzon.decodeWith(ellipse)->Result.map(geo => Ellipse(geo))
+        | "circle" => json->Jzon.decodeWith(circle)->Result.map(geo => Circle(geo))
+        | "rectangle" => json->Jzon.decodeWith(rectangle)->Result.map(geo => Rectangle(geo))
+        | "ellipse" => json->Jzon.decodeWith(ellipse)->Result.map(geo => Ellipse(geo))
         // Properly report bad enum value for pretty errors
         | x => Error(#UnexpectedJsonValue([Field("kind")], x))
         },
@@ -342,23 +339,17 @@ module HowtoDependentSchemaFlat = {
         // Depending on the variant, stringify the tag for the "kind" field and
         // use appropriate params codec for the rest fields
         switch shape {
-        | Circle(r) =>
-          ("circle", r->Jzon.encodeWith(radius))
-        | Rectangle(width, height) =>
-          ("rectangle", (width, height)->Jzon.encodeWith(widthHeight))
-        | Ellipse(width, height) =>
-          ("ellipse", (width, height)->Jzon.encodeWith(widthHeight))
+        | Circle(r) => ("circle", r->Jzon.encodeWith(radius))
+        | Rectangle(width, height) => ("rectangle", (width, height)->Jzon.encodeWith(widthHeight))
+        | Ellipse(width, height) => ("ellipse", (width, height)->Jzon.encodeWith(widthHeight))
         },
       ((kind, json)) =>
         // Depending on the "kind" field value take a proper params codec to decode
         // other fields and build the value in the ReScript world
         switch kind {
-        | "circle" =>
-          json->Jzon.decodeWith(radius)->Result.map(r => Circle(r))
-        | "rectangle" =>
-          json->Jzon.decodeWith(widthHeight)->Result.map(((w, h)) => Rectangle(w, h))
-        | "ellipse" =>
-          json->Jzon.decodeWith(widthHeight)->Result.map(((w, h)) => Ellipse(w, h))
+        | "circle" => json->Jzon.decodeWith(radius)->Result.map(r => Circle(r))
+        | "rectangle" => json->Jzon.decodeWith(widthHeight)->Result.map(((w, h)) => Rectangle(w, h))
+        | "ellipse" => json->Jzon.decodeWith(widthHeight)->Result.map(((w, h)) => Ellipse(w, h))
         // Properly report bad enum value for pretty errors
         | x => Error(#UnexpectedJsonValue([Field("kind")], x))
         },
@@ -375,9 +366,7 @@ module HowtoDependentSchemaFlat = {
     ->Jzon.encodeStringWith(Codecs.shape)
     ->Assert.equals(`{"kind":"rectangle","width":3,"height":4}`)
 
-    Circle(15.0)
-    ->Jzon.encodeStringWith(Codecs.shape)
-    ->Assert.equals(`{"kind":"circle","r":15}`)
+    Circle(15.0)->Jzon.encodeStringWith(Codecs.shape)->Assert.equals(`{"kind":"circle","r":15}`)
   })
 
   test("Flat dependent schema decoding", () => {
@@ -385,9 +374,7 @@ module HowtoDependentSchemaFlat = {
     ->Jzon.decodeStringWith(Codecs.shape)
     ->Assert.equals(Ok(Rectangle(3.0, 4.0)))
 
-    `{"kind":"circle","r":15}`
-    ->Jzon.decodeStringWith(Codecs.shape)
-    ->Assert.equals(Ok(Circle(15.0)))
+    `{"kind":"circle","r":15}`->Jzon.decodeStringWith(Codecs.shape)->Assert.equals(Ok(Circle(15.0)))
 
     `{"kind":"donut","r":15}`
     ->Jzon.decodeStringWith(Codecs.shape)

--- a/tests/Object_test.res
+++ b/tests/Object_test.res
@@ -43,15 +43,15 @@ module Codecs = {
 }
 
 test("Nested object", () => {
-  Codecs.vertex
-  ->Jzon.decodeString(`{
+  `{
     "x": 10,
     "y": 20,
     "look": {
       "color": "#09a",
       "size": 5.0
     }
-  }`)
+  }`
+  ->Jzon.decodeStringWith(Codecs.vertex)
   ->Assert.okOf(
     {x: 10.0, y: 20.0, look: Some({color: "#09a", size: 5.0})},
     ~message="Decodes correctly",
@@ -65,44 +65,44 @@ test("Nested object", () => {
 })
 
 test("Nested object optional field", () => {
-  Codecs.vertex
-  ->Jzon.decodeString(`{"x": 10, "y": 20}`)
+  `{"x": 10, "y": 20}`
+  ->Jzon.decodeStringWith(Codecs.vertex)
   ->Assert.okOf({x: 10.0, y: 20.0, look: None}, ~message="Decodes to None if absent")
 
-  Codecs.vertex
-  ->Jzon.decodeString(`{"x": 10, "y": 20, "look": null}`)
+  `{"x": 10, "y": 20, "look": null}`
+  ->Jzon.decodeStringWith(Codecs.vertex)
   ->Assert.okOf({x: 10.0, y: 20.0, look: None}, ~message="Decodes to None if null")
 
-  Codecs.vertex
-  ->Jzon.encode({x: 10.0, y: 20.0, look: None})
+  {x: 10.0, y: 20.0, look: None}
+  ->Jzon.encodeWith(Codecs.vertex)
   ->Js.Json.stringify
   ->Assert.equals(`{"x":10,"y":20}`, ~message="Encoding omits nulls")
 })
 
 test("Object field default value", () => {
-  Codecs.link
-  ->Jzon.decodeString(`{"start": 0, "end": 1}`)
+  `{"start": 0, "end": 1}`
+  ->Jzon.decodeStringWith(Codecs.link)
   ->Assert.okOf({start: 0, end: 1, weight: 1.0}, ~message="Used if absent")
 
-  Codecs.link
-  ->Jzon.decodeString(`{"start": 0, "end": 1, "weight": null}`)
+  `{"start": 0, "end": 1, "weight": null}`
+  ->Jzon.decodeStringWith(Codecs.link)
   ->Assert.okOf({start: 0, end: 1, weight: 1.0}, ~message="Used if null")
 })
 
 test("Object JSON with missing field", () => {
-  Codecs.look
-  ->Jzon.decodeString(`{"color": "#09a"}`)
+  `{"color": "#09a"}`
+  ->Jzon.decodeStringWith(Codecs.look)
   ->Assert.errorString(`Missing field "size" at .`, ~message="Errors")
 })
 
 test("Object JSON with missing nested field", () => {
-  Codecs.vertex
-  ->Jzon.decodeString(`{"x": 10, "y": 20, "look": {"color": "#09a"}}`)
+  `{"x": 10, "y": 20, "look": {"color": "#09a"}}`
+  ->Jzon.decodeStringWith(Codecs.vertex)
   ->Assert.errorString(`Missing field "size" at ."look"`, ~message="Errors with proper path")
 })
 
 test("Object JSON with unexpected type", () => {
-  Codecs.vertex
-  ->Jzon.decodeString(`{"x": 10, "y": 20, "look": {"color": "#09a", "size": "laaaarge"}}`)
+  `{"x": 10, "y": 20, "look": {"color": "#09a", "size": "laaaarge"}}`
+  ->Jzon.decodeStringWith(Codecs.vertex)
   ->Assert.errorString(`Expected number, got string at ."look"."size"`, ~message="Errors")
 })

--- a/tests/TaggedUnion_test.res
+++ b/tests/TaggedUnion_test.res
@@ -35,12 +35,12 @@ module Codecs = {
 }
 
 test("Tagged union", () => {
-  Codecs.shape
-  ->Jzon.decodeString(`{
+  `{
     "kind": "rectangle",
     "width": 3,
     "height": 4
-  }`)
+  }`
+  ->Jzon.decodeStringWith(Codecs.shape)
   ->Assert.okOf(Rectangle(3.0, 4.0), ~message="decodes correctly")
 
   Assert.roundtrips(Ellipse(1.0, 4.0), Codecs.shape, ~message="does roundtrip")


### PR DESCRIPTION
Introduce `Jzon.encodeWith` and `Jzon.decodeWith`.

Their usage is encouraged over `Jzon.encode` and `Jzon.decode` due to experience from real-world scenarios. The original functions are kept intact if one still prefers them.