### PR TITLE
Rename Jzon.default to Jzon.defaultTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module Codecs = {
     Jzon.field("x", Jzon.float),
     Jzon.field("y", Jzon.float),
     // ... supports default values
-    Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+    Jzon.field("z", Jzon.float)->Jzon.defaultTo(0.0),
     // ... may refer your other codecs
     Jzon.field("style", style)->Jzon.optional,
   )

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,7 +131,7 @@ let optional: field<'v> => field<option<'v>>
 Makes the given field optional. The field will be decoded to the `None` value if the given field key is missing in the JSON object _or_ if the key is there but its value is `null`. While encoding, if the ReScript value is `None` the given field key will be omitted from the resulting JSON.
 
 ```rescript
-let default: (field<'v>, 'v) => field<'v>
+let defaultTo: (field<'v>, 'v) => field<'v>
 ```
 
 Makes the given field optional. The field will be decoded to the default fallback value provided if the given field key is missing in the JSON object _or_ if the key is there but its value is `null`. While encoding, the resulting JSON always includes the key, even if the value is equal to the default.

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -64,9 +64,9 @@ module Codecs = {
     ((x, y, z, color)) => {x, y, z, color}->Ok,
     Jzon.field("x", Jzon.float),
     Jzon.field("y", Jzon.float),
-    // Use Jzon.default adapter to provide a fallback value in case
+    // Use Jzon.defaultTo adapter to provide a fallback value in case
     // the field is missing
-    Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+    Jzon.field("z", Jzon.float)->Jzon.defaultTo(0.0),
     // Use Jzon.optional adapter to make the value indeed option’al
     Jzon.field("color", Jzon.string)->Jzon.optional,
   )
@@ -189,7 +189,7 @@ test("Array decoding", () => {
   )
 
   // Missing field does not mean an empty array by default. However, you may use
-  // the `default([])` field adaptor to express just that.
+  // the `defaultTo([])` field adaptor to express just that.
   `{"title": "My Plot"}`
   ->Jzon.decodeStringWith(Codecs.plot)
   ->Assert.equals(Error(#MissingField([], "points")))

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ module Codecs = {
     Jzon.field("x", Jzon.float),
     Jzon.field("y", Jzon.float),
     // ... supports default values
-    Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+    Jzon.field("z", Jzon.float)->Jzon.defaultTo(0.0),
     // ... may refer your other codecs
     Jzon.field("style", style)->Jzon.optional,
   )

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "ejs": "^3.1.6",
-    "rescript": "^11.0.0",
+    "rescript": "^11.1.0",
     "rescript-js": "1.0.0-beta.2",
     "rescript-test": "^3.1.0"
   },
@@ -21,6 +21,6 @@
     "json"
   ],
   "dependencies": {
-    "@rescript/core": "^1.1.0"
+    "@rescript/core": "^1.6.1"
   }
 }

--- a/rescript.json
+++ b/rescript.json
@@ -16,7 +16,7 @@
   ],
   "package-specs": [
     {
-      "module": "commonjs",
+      "module": "esmodule",
       "in-source": true
     }
   ],

--- a/src/Jzon.res
+++ b/src/Jzon.res
@@ -27,7 +27,7 @@ module DecodingError = {
       | Index(index) => `[` ++ index->Int.toString ++ `]`
       }
     )
-    ->Array.joinWith(".")
+    ->Array.join(".")
 
   let prependLocation = (err, loc) =>
     switch err {
@@ -273,7 +273,7 @@ type field<'v> = Field.t<'v>
 let field = (key, codec) => Field.make(Key(key), codec)
 let self = Field.make(Self, Codec.identity)
 let optional = Field.makeOptional
-let default = Field.assignDefault
+let defaultTo = Field.assignDefault
 
 let jsonObject = keyVals => JSON.Encode.object(Dict.fromArray([]->Array.concatMany(keyVals)))
 

--- a/src/Jzon.resi
+++ b/src/Jzon.resi
@@ -43,7 +43,7 @@ let dict: codec<'v> => codec<Js.Dict.t<'v>>
 let field: (string, codec<'v>) => field<'v>
 let self: field<Js.Json.t>
 let optional: field<'v> => field<option<'v>>
-let default: (field<'v>, 'v) => field<'v>
+let defaultTo: (field<'v>, 'v) => field<'v>
 
 let asObject: Js.Json.t => result<Js.Dict.t<Js.Json.t>, DecodingError.t>
 

--- a/tests/Howtos_test.res
+++ b/tests/Howtos_test.res
@@ -26,7 +26,7 @@ module Quickstart = {
       ((x, y, z, style)) => {x, y, z, style}->Ok,
       Jzon.field("x", Jzon.float),
       Jzon.field("y", Jzon.float),
-      Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+      Jzon.field("z", Jzon.float)->Jzon.defaultTo(0.0),
       Jzon.field("style", style)->Jzon.optional,
     )
   }
@@ -99,9 +99,9 @@ module HowtoOptionalDefault = {
       ((x, y, z, color)) => {x, y, z, color}->Ok,
       Jzon.field("x", Jzon.float),
       Jzon.field("y", Jzon.float),
-      // Use Jzon.default adapter to provide a fallback value in case
+      // Use Jzon.defaultTo adapter to provide a fallback value in case
       // the field is missing
-      Jzon.field("z", Jzon.float)->Jzon.default(0.0),
+      Jzon.field("z", Jzon.float)->Jzon.defaultTo(0.0),
       // Use Jzon.optional adapter to make the value indeed option’al
       Jzon.field("color", Jzon.string)->Jzon.optional,
     )

--- a/tests/Object_test.res
+++ b/tests/Object_test.res
@@ -38,7 +38,7 @@ module Codecs = {
     ((start, end, weight)) => {start, end, weight}->Ok,
     Jzon.field("start", Jzon.int),
     Jzon.field("end", Jzon.int),
-    Jzon.field("weight", Jzon.float)->Jzon.default(1.0),
+    Jzon.field("weight", Jzon.float)->Jzon.defaultTo(1.0),
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@rescript/core@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@rescript/core/-/core-1.1.0.tgz#e228a2635665b6b6a3288f7fd58552d5c361e253"
-  integrity sha512-pz/CL8+9hBUTeMpUouvZohNsa5rqIwurlXoa1CZWN0ZKuWjMVjaoQ3V+0NB72J/QBbs6/8W82VABKBaDn3fGCA==
+"@rescript/core@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@rescript/core/-/core-1.6.1.tgz#159670c94d64a2b8236f46be2bf09a007b1ece08"
+  integrity sha512-vyb5k90ck+65Fgui+5vCja/mUfzKaK3kOPT4Z6aAJdHLH1eljEi1zKhXroCiCtpNLSWp8k4ulh1bdB5WS0hvqA==
 
 "@ryyppy/rescript-promise@^2.1.0":
   version "2.1.0"
@@ -590,10 +590,10 @@ rescript-test@^3.1.0:
   dependencies:
     jsdom "16.4.0"
 
-rescript@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/rescript/-/rescript-11.0.0.tgz#9a0b6fc998c360543c459aba49b77a572a0306cd"
-  integrity sha512-uIUwDZZmDUb7ymGkBiiGioxMg8hXh1mze/2k/qhYQcZGgi7PrLHQIW9AksM7gb9WnpjCAvFsA8U2VgC0nA468w==
+rescript@^11.1.0:
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/rescript/-/rescript-11.1.4.tgz#9a42ebc4fc5363707e39cef5b3188160b63bee42"
+  integrity sha512-0bGU0bocihjSC6MsE3TMjHjY0EUpchyrREquLS8VsZ3ohSMD+VHUEwimEfB3kpBI1vYkw3UFZ3WD8R28guz/Vw==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.1"


### PR DESCRIPTION
- Rename `Jzon.default` to `Jzon.defaultTo` because function name `default` leads to incorrect Webpack/NextJS SSR bundling in some scenarios: they confuse it with the default module export
- Upgrade `rescript` dependency to 11.1
- Upgrade `@rescript/core` dependency to 1.6.1